### PR TITLE
Add z-index to the debugger container

### DIFF
--- a/src/overwrite/Game.ts
+++ b/src/overwrite/Game.ts
@@ -83,6 +83,7 @@ function applyCustomStyleToPane(pane: any) {
         overflow: hidden auto;
         max-height: ${window.innerHeight - 20}px;
         resize: vertical;
+        z-index: 9999;
     }
 
     #tweenpane_phaser_debug::-webkit-scrollbar {


### PR DESCRIPTION
I've ran into this issue where the debugger container gets behind other scenes.

closes #7